### PR TITLE
bugfix/get mock port error

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -1,14 +1,7 @@
 import lyrebird
 import pip
-import time
-import asyncio
-from asyncio import Event
-import threading
 
 
 if __name__ == '__main__':
     pip.main(['install', '.',  '--upgrade'])
     lyrebird.debug()
-
-    loop = asyncio.get_event_loop()
-    loop.run_forever()

--- a/debug.py
+++ b/debug.py
@@ -1,8 +1,14 @@
 import lyrebird
 import pip
+import time
+import asyncio
+from asyncio import Event
+import threading
 
 
 if __name__ == '__main__':
     pip.main(['install', '.',  '--upgrade'])
     lyrebird.debug()
 
+    loop = asyncio.get_event_loop()
+    loop.run_forever()

--- a/debug.py
+++ b/debug.py
@@ -5,3 +5,4 @@ import pip
 if __name__ == '__main__':
     pip.main(['install', '.',  '--upgrade'])
     lyrebird.debug()
+

--- a/lyrebird_android/ui.py
+++ b/lyrebird_android/ui.py
@@ -138,7 +138,7 @@ class MyUI(lyrebird.PluginView):
         conf = config.load()
         app = device.package_info(conf.package_name)
         device.stop_app(conf.package_name)
-        port = lyrebird.context.application.conf.get('mock').get('port')
+        port = lyrebird.context.application.conf.get('mock.port')
         device.start_app(app.launch_activity, get_ip(), port)
         return context.make_ok_response()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lyrebird-android',
-    version='0.1.8',
+    version='0.1.9',
     packages=['lyrebird_android'],
     url='https://github.com/meituan/lyrebird-android',
     author='HBQA',


### PR DESCRIPTION
Data structure of mock port changed since lyrebird v0.10.0, the previous way is not available to get right data.

FIX: get mock port error