### PR TITLE
Feature/confirm lyrebird 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,3 @@ jobs:
         - pip install .
       # command to run tests
       script: pytest
-
-    - stage: release to pypi
-      if: type = push
-      language: python
-      catch: pip
-      python:
-        - "3.6"
-      script:
-        - echo "Skipping tests"
-      deploy:
-        provider: pypi
-        user: $PYPI_USER
-        password:
-          secure: $PYPI_SECURE
-        on:
-          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+jobs:
+  include:
+    - stage: unit test
+      language: python
+      catch: pip
+      python:
+        - "3.6"
+      # command to install dependencies
+      install:
+        - pip install -r requirements.txt
+        - pip install .
+      # command to run tests
+      script: pytest
+
+    - stage: release to pypi
+      if: type = push
+      language: python
+      catch: pip
+      python:
+        - "3.6"
+      script:
+        - echo "Skipping tests"
+      deploy:
+        provider: pypi
+        user: $PYPI_USER
+        password:
+          secure: $PYPI_SECURE
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,19 @@ jobs:
         - pip install .
       # command to run tests
       script: pytest
+
+    - stage: release to pypi
+      if: type = push
+      language: python
+      catch: pip
+      python:
+        - "3.6"
+      script:
+        - echo "Skipping tests"
+      deploy:
+        provider: pypi
+        user: yumiguan
+        password:
+          secure: "CN10CV5Dl3WXp6ZQ8eN1EgfsZ3RqZA4+jtkLGA8kQ5VdNnCieG0IbQQlTtXu5UjBMxjZ5a9Q8+ymkRU6EAixsSIdBEmxKx7V8Ift/fH2nInxMJ0epSVV7i0NasopkXXHEpYCbLAz3XTo2+sFCLvdePMTmvqd8AkazGzyHtzLR1oL7G2sMuOEDPKeavXF7QcPFT6z5S0YkGKGZFXkI68LEZQcwUrKKFQHrX2HQkdZEiJoB4+cIRAo8bQ38YXzNWW+7PV+hePo4wuKqnd8rBclqD04RtUvzVG89/oyVZKP302mG2y+XsD7q43LOOnvx0LebWgzlcqATNT3kNdJ3Ac0YPCHDo+EmMk0NvnFQfF81tQQ5HBzDkWztg+RJ/f7MiU7LInFk1dWOwmjOs6sNnrxKAgjps6UN6jk9/8eTuowOPDww8SVmPB4niaLzwXYTzX1/KWestnZJW2c9u7G0Ba3+yFcykG1Zvq5hP9X7/Uv8MUcwjJEVp1tZ8d5SLyDzGt9XhS4ys5k/jsqQpXvog3Ax1c8dNQTi0pqv7fU8cEnQyH+FkMTMvkfUDwK4wMpPNGWxD9lc30XgJDleu7r3LH+tCQpD9toUcqAmDO2fcdZr+p4qwKI7zChLKqyDtIB4+0iSasYpQ9PeLUd6Wv7ushFBLbyNrV7V7doTIumFGao8Vo="
+        on:
+          tags: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Lyrebird Android plugin
+[![Build Status](https://travis-ci.org/meituan/lyrebird-android.svg?branch=master)](https://travis-ci.org/meituan/lyrebird-android)
+![GitHub](https://img.shields.io/github/license/meituan/lyrebird-android.svg)
 
 **[Lyrebird](https://github.com/meituan/lyrebird)是一个基于拦截以及模拟HTTP/HTTPS网络请求的面向移动应用的插件化测试平台。**
 

--- a/lyrebird_android/android_helper.py
+++ b/lyrebird_android/android_helper.py
@@ -88,7 +88,7 @@ class App:
             if app.version_name and app.version_code and actionMAIN_line_num:
                 package_name_line = lines[actionMAIN_line_num]
                 app.launch_activity = package_name_line.strip().split()[1]
-                return app
+                break
 
         return app
 
@@ -382,8 +382,10 @@ def devices():
         return []
     
     lines = [line for line in output.split('\n') if line]
-    online_devices = {} # information for plugin own
-    devices_info = [] # information for bugit
+    # online_devices contains information for plugin own
+    online_devices = {}
+    # devices_info contains information for bugit
+    devices_info = []
     
     # no device connected
     if len(lines) > 1:

--- a/lyrebird_android/android_helper.py
+++ b/lyrebird_android/android_helper.py
@@ -222,10 +222,17 @@ class Device:
                     log_filtered_file.flush()
                 
                 if self.crash_checker(line) and self.log_filter(line, pid_target):
-                    item = {'name':'crash', 'message':str(line.decode(encoding='UTF-8', errors='ignore'))}
-                    lyrebird.publish('device', item)
                     crash_filtered_file.writelines(line.decode(encoding='UTF-8', errors='ignore'))
                     crash_filtered_file.flush()
+                    # send Android.crash event
+                    item = [{
+                            'id':self.device_id, 
+                            'crash':[
+                                {'name':'crash_log', 'path':self._crash_filtered_file}, 
+                                {'name':'screenshot', 'path':self.take_screen_shot()}
+                            ] 
+                        }]
+                    lyrebird.publish('Android.crash', item, state=True)
 
                 if self.anr_checker(line):
                     anr_file_name = os.path.join(anr_dir, 'android_anr_%s.log' % self.device_id)
@@ -240,9 +247,17 @@ class Device:
                          if p2_line:
                             pid_target.append(str(p2_line).strip().split( )[1])
                     if str(anr_headline).strip().split()[2] in pid_target:
-                        item = {'name':'anr', 'message':str(line.decode(encoding='UTF-8', errors='ignore'))}
-                        lyrebird.publish('device', item)
                         subprocess.run(f'{adb} -s {self.device_id} pull "/data/anr/traces.txt" {self._anr_filtered_file}', shell=True, stdout=subprocess.PIPE)
+
+                        # send Android.crash event
+                        item = [{
+                            'id':self.device_id, 
+                            'crash':[
+                                {'name':'anr_log', 'path':self._anr_filtered_file}, 
+                                {'name':'screenshot', 'path':self.take_screen_shot()}
+                            ] 
+                        }]
+                        lyrebird.publish('Android.crash', item, state=True)
                         
                 self._log_cache.append(line.decode(encoding='UTF-8', errors='ignore'))
 
@@ -380,4 +395,25 @@ def devices():
     for line in lines[1:]:
         device = Device.from_adb_line(line)
         online_devices[device.device_id] = device
+
+    # send Android.device event
+    devices_list = []
+    for device_id in online_devices:
+        device_detail = online_devices[device_id]
+        item = {}
+        item['id'] = device_id
+        item['info'] = {
+            'product': device_detail.product,
+            'model': device_detail.model
+        }
+        for line in device_detail.device_info:
+            if 'ro.build.version.release' in line:
+                item['info']['os'] = line[line.rfind('[') + 1:line.rfind(']')].strip()
+                break
+        devices_list.append(item)
+
+    last_devices_list = lyrebird.state.get('Android.device')
+    if devices_list != last_devices_list:
+        lyrebird.publish('Android.device', devices_list, state=True)
+
     return online_devices

--- a/lyrebird_android/android_helper.py
+++ b/lyrebird_android/android_helper.py
@@ -6,7 +6,7 @@ import json
 import time
 import codecs
 from lyrebird import context
-from lyrebird import get_logger
+from lyrebird.log import get_logger
 import lyrebird
 from . import config
 
@@ -159,7 +159,7 @@ class Device:
             if len(info_kv) >= 2:
                 setattr(_device, info_kv[0], info_kv[1])
             else:
-                logger.error('Read device info error: unknown format', info_kv)
+                logger.error(f'Read device info error: unknown format {info_kv}')
         return _device
 
     def install(self, apk_file):

--- a/lyrebird_android/android_helper.py
+++ b/lyrebird_android/android_helper.py
@@ -229,10 +229,9 @@ class Device:
                             'id':self.device_id, 
                             'crash':[
                                 {'name':'crash_log', 'path':self._crash_filtered_file}, 
-                                {'name':'screenshot', 'path':self.take_screen_shot()}
                             ] 
                         }]
-                    lyrebird.publish('Android.crash', item, state=True)
+                    lyrebird.publish('android.crash', item)
 
                 if self.anr_checker(line):
                     anr_file_name = os.path.join(anr_dir, 'android_anr_%s.log' % self.device_id)
@@ -254,10 +253,9 @@ class Device:
                             'id':self.device_id, 
                             'crash':[
                                 {'name':'anr_log', 'path':self._anr_filtered_file}, 
-                                {'name':'screenshot', 'path':self.take_screen_shot()}
                             ] 
                         }]
-                        lyrebird.publish('Android.crash', item, state=True)
+                        lyrebird.publish('android.crash', item)
                         
                 self._log_cache.append(line.decode(encoding='UTF-8', errors='ignore'))
 
@@ -412,8 +410,8 @@ def devices():
                 break
         devices_list.append(item)
 
-    last_devices_list = lyrebird.state.get('Android.device')
+    last_devices_list = lyrebird.state.get('android.device')
     if devices_list != last_devices_list:
-        lyrebird.publish('Android.device', devices_list, state=True)
+        lyrebird.publish('android.device', devices_list, state=True)
 
     return online_devices

--- a/lyrebird_android/config.py
+++ b/lyrebird_android/config.py
@@ -6,7 +6,7 @@ import lyrebird
 """
 Android plugin config manager
 """
-    
+
 storage = lyrebird.get_plugin_storage()
 CONFIG_FILE = os.path.abspath(os.path.join(storage, 'conf.json'))
 

--- a/lyrebird_android/config.py
+++ b/lyrebird_android/config.py
@@ -1,12 +1,12 @@
-import lyrebird
 import os
 import json
 import codecs
+import lyrebird
 
 """
 Android plugin config manager
 """
-
+    
 storage = lyrebird.get_plugin_storage()
 CONFIG_FILE = os.path.abspath(os.path.join(storage, 'conf.json'))
 
@@ -24,10 +24,7 @@ class Config:
 
 
 def load():
-    if os.path.exists(CONFIG_FILE):
-        conf_data = json.loads(codecs.open(CONFIG_FILE, 'r', 'utf-8').read())
-        conf = Config()
-        conf.__dict__ = conf_data
-        return conf
-    else:
-        return Config()
+    conf = Config()
+    conf.package_name = lyrebird.context.application.conf.get('android_package')
+    # conf.package_name = "com.sankuai.meituan"
+    return conf

--- a/lyrebird_android/config.py
+++ b/lyrebird_android/config.py
@@ -22,9 +22,7 @@ class Config:
         conf_file.write(json_str)
         conf_file.close()
 
-
 def load():
     conf = Config()
     conf.package_name = lyrebird.context.application.conf.get('android_package')
-    # conf.package_name = "com.sankuai.meituan"
     return conf

--- a/lyrebird_android/ui.py
+++ b/lyrebird_android/ui.py
@@ -225,6 +225,19 @@ class MyUI(lyrebird.PluginView):
 
         return app_info_file_path
 
+    def get_screenshots(self):
+        screenshot_list = []
+        for device_id in device_service.devices:
+            device_detail = device_service.devices[device_id]
+            item = {}
+            item['id'] = device_id
+            item['screenshot'] = {
+                'name': 'screenshot',
+                'path': device_detail.take_screen_shot()
+            }
+            screenshot_list.append(item)
+        lyrebird.publish('android.screenshot', screenshot_list)
+
     def on_create(self):
         # for overbridge
         self.add_url_rule('/api/info', view_func=self.info)
@@ -250,6 +263,8 @@ class MyUI(lyrebird.PluginView):
         self.on_event('log-start', self.logcat_start, '/android-plugin')
         # 启动设备监听服务
         lyrebird.start_background_task(device_service.run)
+        # 订阅频道 android.cmd
+        lyrebird.subscribe('android.cmd', self.get_screenshots)
 
     def get_icon(self):
         return 'fa fa-fw fa-android'

--- a/lyrebird_android/ui.py
+++ b/lyrebird_android/ui.py
@@ -225,7 +225,7 @@ class MyUI(lyrebird.PluginView):
 
         return app_info_file_path
 
-    def get_screenshots(self):
+    def get_screenshots(self, message):
         screenshot_list = []
         for device_id in device_service.devices:
             device_detail = device_service.devices[device_id]
@@ -264,7 +264,7 @@ class MyUI(lyrebird.PluginView):
         # 启动设备监听服务
         lyrebird.start_background_task(device_service.run)
         # 订阅频道 android.cmd
-        lyrebird.subscribe('android.cmd', self.get_screenshots())
+        lyrebird.subscribe('android.cmd', self.get_screenshots)
 
     def get_icon(self):
         return 'fa fa-fw fa-android'

--- a/lyrebird_android/ui.py
+++ b/lyrebird_android/ui.py
@@ -1,12 +1,12 @@
-from flask import request, jsonify, send_from_directory
-from lyrebird import context
-import lyrebird
-from .device_service import DeviceService
-from . import config
-import codecs
-import time
 import os
+import time
 import socket
+import codecs
+import lyrebird
+from . import config
+from lyrebird import context
+from .device_service import DeviceService
+from flask import request, jsonify, send_from_directory
 
 
 device_service = DeviceService()
@@ -105,11 +105,11 @@ class MyUI(lyrebird.PluginView):
 
         for udid in devices:
             device = devices[udid]
-            if os.path.getsize(device.log_filtered_file):
+            if device.log_filtered_file and os.path.getsize(device.log_filtered_file):
                 res.append(self.make_dump_data(device.log_filtered_file))
-            if os.path.getsize(device.crash_filtered_file):
+            if device.crash_filtered_file and os.path.getsize(device.crash_filtered_file):
                 res.append(self.make_dump_data(device.crash_filtered_file))
-            if os.path.getsize(device.anr_filtered_file):
+            if device.anr_filtered_file and os.path.getsize(device.anr_filtered_file):
                 res.append(self.make_dump_data(device.anr_filtered_file))
             if len(self.get_app_info_file_path(device)):
                 res.append(self.make_dump_data(self.get_app_info_file_path(device)))
@@ -165,11 +165,11 @@ class MyUI(lyrebird.PluginView):
         if device:
             device.take_screen_shot()
         dump_list = [device.screen_shot_file, self.get_prop_file_path(device, device_id)]
-        if os.path.getsize(device.log_filtered_file):
+        if device.log_filtered_file and os.path.getsize(device.log_filtered_file):
             dump_list.append(device.log_filtered_file)
-        if os.path.getsize(device.crash_filtered_file):
+        if device.crash_filtered_file and os.path.getsize(device.crash_filtered_file):
             dump_list.append(device.crash_filtered_file)
-        if os.path.getsize(device.anr_filtered_file):
+        if device.anr_filtered_file and os.path.getsize(device.anr_filtered_file):
             dump_list.append(device.anr_filtered_file)
         if len(self.get_app_info_file_path(device)):
             dump_list.append(self.get_app_info_file_path(device))
@@ -264,7 +264,7 @@ class MyUI(lyrebird.PluginView):
         # 启动设备监听服务
         lyrebird.start_background_task(device_service.run)
         # 订阅频道 android.cmd
-        lyrebird.subscribe('android.cmd', self.get_screenshots)
+        lyrebird.subscribe('android.cmd', self.get_screenshots())
 
     def get_icon(self):
         return 'fa fa-fw fa-android'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lyrebird-android',
-    version='0.1.9',
+    version='0.1.10',
     packages=['lyrebird_android'],
     url='https://github.com/meituan/lyrebird-android',
     author='HBQA',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lyrebird-android',
-    version='0.1.10',
+    version='0.1.11',
     packages=['lyrebird_android'],
     url='https://github.com/meituan/lyrebird-android',
     author='HBQA',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='lyrebird-android',
-    version='0.1.11',
+    version='0.1.12',
     packages=['lyrebird_android'],
     url='https://github.com/meituan/lyrebird-android',
     author='HBQA',

--- a/tests/test_android_helper.py
+++ b/tests/test_android_helper.py
@@ -1,39 +1,8 @@
-#coding=utf-8
-
 from lyrebird_android.android_helper import Device
-import lyrebird_android.android_helper as ah
-from unittest import TestCase
-import unittest, os
+import pytest
 
 
-class TestAndroidHelper(TestCase):
-
-    def test_anr_checker(self):
-        ANR_TEST_DATA = [
-        "03-15 17:16:06.049 864 2787 I WindowManager: Input event dispatching timed out sending to com.example.lee.test/com.example.lee.test.MainActivity. Reason: Waiting to send non-key event because the touched window has not finished processing certain input events that were delivered to it over 500.0ms ago. Wait queue length: 32. Wait queue head age: 5736.5ms.",
-        "03-15 17:16:09.190 864 877 E ActivityManager: ANR in com.example.lee.test (com.example.lee.test/.MainActivity)",
-        "03-15 17:16:09.190 864 877 E ActivityManager: PID: 16384",
-        "03-15 17:16:09.190 864 877 E ActivityManager: Reason: Input dispatching timed out (Waiting to send non-key event because the touched window has not finished processing certain input events that were delivered to it over 500.0ms ago. Wait queue length: 32. Wait queue head age: 5736.5ms.)"
-                ]
-        ah.check_android_home()
-        d = Device('192.168.56.101:5555')
-
-        for line in ANR_TEST_DATA:
-            Device.anr_checker(d, line)
-        self.assertTrue(os.path.exists(str(d.anr_file)), 'Traces.txt NOT FOUND!')
-
-    def test_crash_checker(self):
-        CRASH_TEST_DATA = [
-            "--------- beginning of crash",
-            "03-15 11:38:27.668 11593 11593 E AndroidRuntime: FATAL EXCEPTION: main",
-            "03-15 11:38:27.668 11593 11593 E AndroidRuntime: Process: com.example.lee.test, PID: 11593",
-            "03-15 11:38:27.668 11593 11593 E AndroidRuntime: java.lang.IllegalStateException: Could not execute method for android:onClick",
-            "03-15 11:38:27.677 864 3838 W ActivityManager: Force finishing activity com.example.lee.test/.MainActivity"
-        ]
-        d = Device('192.168.56.101:5555')
-        for line in CRASH_TEST_DATA:
-            Device.crash_checker(d, line)
-        self.assertTrue(len(d._crash_file_list), 'Crash log NOT CREATE!')
-
-if __name__ == '__main__':
-    unittest.main()
+def test_package_name(self):
+    device_info_str = "00c34258893533x       device usb:337641472X product:bullhead model:Nexus_5X device:bullhead transport_id:24"
+    device_info_dict = Device.from_adb_line(device_info_str)
+    assert len(device_info_dict.model) > 0 


### PR DESCRIPTION
1. FIX:
 - Unable to send device list when device list is empty
 - Failure to send device list when device_info is empty
 - Unable to get android.intent.action.MAIN of application
 - Failure to get size of crash log
 - Send event to bugit ail

2. UPDATE
 - Fit lyrebird 0.13.0

3. ADD
 - PyPI auto release

-------------------
1. 修复
 - 设备列表变更为空时，未向bugit上报变更后的设备列表
 - device_info为空时，向bugit上报设备信息时异常
 - 无法获取应用android.intent.action.MAIN的错误
 - 获取路径不存在的crash文件的大小时的异常
 - 向bugit发送截图时的异常

2. 更新
 - 适配lyrebird 0.13.0 config机制

3. 新增
 - pypi自动发布